### PR TITLE
Required test dependency to run Test Harness

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,13 @@
 
   <dependencies>
     <dependency>
+        <groupId>org.codehaus.plexus</groupId>
+        <artifactId>plexus-utils</artifactId>
+        <version>[1.5.2,)</version>
+        <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>javadoc</artifactId>
       <version>1.0</version>


### PR DESCRIPTION
When running mvn verify some missing dependencies affected the build, although when running mvn test everything seems to be smooth.

Quick fix, although considering to upgrade the pom parent dependency 

``` bash
 T E S T S
-------------------------------------------------------
Running InjectedTest
Running org.jenkins.ci.plugins.jenkinslint.check.ArtifactCheckerTestCase
Tests run: 2, Failures: 0, Errors: 2, Skipped: 0, Time elapsed: 6.753 sec <<< FAILURE! - in InjectedTest
org.jvnet.hudson.test.JellyTestSuiteBuilder$JellyTestSuite(org.jvnet.hudson.test.junit.FailedTest)  Time elapsed: 0.011 sec  <<< ERROR!
java.lang.NoSuchMethodError: org.codehaus.plexus.util.StringUtils.isBlank(Ljava/lang/String;)Z
	at org.apache.maven.settings.validation.DefaultSettingsValidator.validate(DefaultSettingsValidator.java:65)
	at org.apache.maven.settings.building.DefaultSettingsBuilder.readSettings(DefaultSettingsBuilder.java:194)
	at org.apache.maven.settings.building.DefaultSettingsBuilder.build(DefaultSettingsBuilder.java:95)
	at hudson.maven.MavenEmbedder.getSettings(MavenEmbedder.java:259)
	at hudson.maven.MavenEmbedder.buildMavenExecutionRequest(MavenEmbedder.java:157)
```